### PR TITLE
Only require activeTab + cookies permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,10 @@
     "manifest_version": 2,
     "name": "Clear Cookie and Reload",
     "description": "Clear Cookie for current tab and reload",
-    "version": "0.3",
+    "version": "0.4",
     "permissions": [
         "cookies",
-        "tabs",
-        "http://*/*",
-        "https://*/*"
+        "activeTab"
     ],
     "background": {
         "scripts": [


### PR DESCRIPTION
Since the extension works on the active page, you can simply declare the permission for the current page rather than every website.  IMHO it makes it more likely for users to trust that it won't be updated to anything nefarious.